### PR TITLE
Screen control register Vertical raster scroll incorrect

### DIFF
--- a/src/export.ts
+++ b/src/export.ts
@@ -413,7 +413,7 @@ Src equ $02
 Dest equ $04
 
 Start:
-    lda #$38   ; 25 rows, on, bitmap
+    lda #$3B   ; 25 rows, on, bitmap
     sta $d011  ; VIC control #1
     lda #$18   ; 40 column, multicolor
     sta $d016  ; VIC control #2


### PR DESCRIPTION
I noticed you had $38 which causes the vic scroll to be "0" which pushes the image up on the screen. The value should be $3B (setting the lower three bits to %011), which is the default "neutral" scroll for the system. The Hires FLI demo also uses this $38 value but that scroll is changed the next frame so it doesn't cause any issues.